### PR TITLE
Changed labels to standard

### DIFF
--- a/graphics/map.svg
+++ b/graphics/map.svg
@@ -1328,7 +1328,7 @@
 
 <text
    xml:space="preserve"
-   style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
+   style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
    x="358.67157"
    y="214.90002"
    id="text6551"
@@ -1337,7 +1337,7 @@
      id="tspan6553"
      x="358.67157"
      y="214.90002"
-     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Norge</tspan></text>
+     style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Norway</tspan></text>
 
 
 
@@ -1369,7 +1369,7 @@
      id="tspan6557"
      x="413"
      y="242.90002"
-     style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Sverige</tspan></text>
+     style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Sweden</tspan></text>
 
 
 
@@ -1392,7 +1392,7 @@
 
 <text
    xml:space="preserve"
-   style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
+   style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
    x="501.17157"
    y="196.90002"
    id="text6559"
@@ -1401,7 +1401,7 @@
      id="tspan6561"
      x="501.17157"
      y="196.90002"
-     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Suomi</tspan></text>
+     style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Finland</tspan></text>
 
 
 
@@ -1433,7 +1433,7 @@
      id="tspan6565"
      x="569.46448"
      y="179.03606"
-     style="font-size:22px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Sankt-Petersburg</tspan></text>
+     style="font-size:22px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Saint-Petersburg</tspan></text>
 
 
 
@@ -1464,7 +1464,7 @@
      sodipodi:role="line"
      id="tspan6569"
      x="630.68628"
-     y="294.14267">Moskva</tspan></text>
+     y="294.14267">Moscow</tspan></text>
 
 
 
@@ -1496,7 +1496,7 @@
      id="tspan6573"
      x="506.14645"
      y="307.72845"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Liivimaa</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Livonia</tspan></text>
 
 
 
@@ -1528,7 +1528,7 @@
      id="tspan6577"
      x="464.81802"
      y="372.60715"
-     style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Warszawa</tspan></text>
+     style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Warsaw</tspan></text>
 
 
 
@@ -1560,7 +1560,7 @@
      id="tspan6581"
      x="547.18628"
      y="404.69293"
-     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Ukrayina</tspan></text>
+     style="font-size:18px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Ukraine</tspan></text>
 
 
 
@@ -1624,7 +1624,7 @@
      id="tspan6589"
      x="745.58582"
      y="551.45026"
-     style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Hayastan</tspan></text>
+     style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Armenia</tspan></text>
 
 
 
@@ -1655,7 +1655,7 @@
      sodipodi:role="line"
      id="tspan6597"
      x="731"
-     y="622.7536">Syriac</tspan></text>
+     y="622.7536">Syria</tspan></text>
 
 
 
@@ -1750,7 +1750,7 @@
      id="tspan6601"
      x="628.83276"
      y="612.55688"
-     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Izmir</tspan></text>
+     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Smyrna</tspan></text>
 
 
 
@@ -1773,15 +1773,15 @@
 
 <text
    xml:space="preserve"
-   style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
-   x="573.5849"
-   y="585.32806"
+   style="font-size:9.5px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
+   x="564"
+   y="565"
    id="text6603"
    sodipodi:linespacing="100%"><tspan
      sodipodi:role="line"
      id="tspan6605"
-     x="573.5849"
-     y="585.32806">Istanbul</tspan></text>
+     x="564"
+     y="565">Constantinople</tspan></text>
 
 
 
@@ -1844,7 +1844,7 @@
      sodipodi:role="line"
      id="tspan6617"
      x="518.02942"
-     y="502.9711">Rom\u00E2nia</tspan></text>
+     y="502.9711">Rumania</tspan></text>
 
 
 
@@ -1907,7 +1907,7 @@
      sodipodi:role="line"
      id="tspan6625"
      x="472.48959"
-     y="529.81421">Srbija</tspan></text>
+     y="529.81421">Serbia</tspan></text>
 
 
 
@@ -1938,7 +1938,7 @@
      sodipodi:role="line"
      id="tspan6629"
      x="487.14645"
-     y="592.2536">Ell\u00E1da</tspan></text>
+     y="592.2536">Greece</tspan></text>
 
 
 
@@ -1962,7 +1962,7 @@
 
 <text
    xml:space="preserve"
-   style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
+   style="font-size:13px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
    x="424.41422"
    y="509.92084"
    id="text6635"
@@ -1970,7 +1970,7 @@
      sodipodi:role="line"
      id="tspan6637"
      x="424.41422"
-     y="509.92084">Triest</tspan></text>
+     y="509.92084">Trieste</tspan></text>
 
 
 
@@ -1993,7 +1993,7 @@
 
 <text
    xml:space="preserve"
-   style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
+   style="font-size:13px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;stroke:none;display:inline;font-family:Droid Serif;-inkscape-font-specification:Droid Serif"
    x="437.5"
    y="444.40002"
    id="text6639"
@@ -2002,7 +2002,7 @@
      id="tspan6641"
      x="437.5"
      y="444.40002"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Wien</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Vienna</tspan></text>
 
 
 
@@ -2034,7 +2034,7 @@
      id="tspan6645"
      x="486"
      y="420.40002"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Galizien</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Galatia</tspan></text>
 
 
 
@@ -2066,7 +2066,7 @@
      id="tspan6649"
      x="400.92892"
      y="417.90002"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">B\u00F6hmen</tspan></text>
+     style="font-size:13px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Bohemia</tspan></text>
 
 
 
@@ -2098,7 +2098,7 @@
      id="tspan6653"
      x="370.64645"
      y="461.40002"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Tirol</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Tyrolia</tspan></text>
 
 
 
@@ -2130,7 +2130,7 @@
      sodipodi:role="line"
      id="tspan6661"
      x="318.05026"
-     y="487.60712">Piemonte</tspan></text>
+     y="487.60712">Piedmont</tspan></text>
 
 
 
@@ -2165,7 +2165,7 @@
      id="tspan6777"
      x="310.30896"
      y="656.6911"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Tunes</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Tunis</tspan></text>
 
 
 
@@ -2229,7 +2229,7 @@
      id="tspan6789"
      x="142.13889"
      y="520.48297"
-     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Espa\u00F1a</tspan></text>
+     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Spain</tspan></text>
 
 
 
@@ -2365,7 +2365,7 @@
      sodipodi:role="line"
      id="tspan6825"
      x="212.25336"
-     y="482.16751">Gascogne</tspan></text>
+     y="482.16751">Gascony</tspan></text>
 
 
 
@@ -2429,7 +2429,7 @@
      id="tspan6833"
      x="266.58966"
      y="440.45859"
-     style="font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Bourgogne</tspan></text>
+     style="font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Burgundy</tspan></text>
 
 
 
@@ -2522,7 +2522,7 @@
      sodipodi:role="line"
      id="tspan6845"
      x="254.67978"
-     y="401.67865">Picardie</tspan></text>
+     y="401.67865">Picardy</tspan></text>
 
 
 
@@ -2588,7 +2588,7 @@
      id="tspan6861"
      x="334.35059"
      y="427.60934"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">M\u00FCnchen</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Munich</tspan></text>
 
 
 
@@ -2684,7 +2684,7 @@
      id="tspan6873"
      x="395.05087"
      y="389.89005"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Schlesien</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Silesia</tspan></text>
 
 
 
@@ -2716,7 +2716,7 @@
      id="tspan6877"
      x="436.52753"
      y="348.52429"
-     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Preu\u00DFen</tspan></text>
+     style="font-size:13.73770523px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;fill:#232323;fill-opacity:1;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Prussia</tspan></text>
 
 
 
@@ -3106,7 +3106,7 @@
      id="textPath3086"
      xlink:href="#path3084"><tspan
    id="tspan6665"
-   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Toscana</tspan></textPath></text>
+   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Tuscany</tspan></textPath></text>
 
 
 
@@ -3140,7 +3140,7 @@
      id="textPath3891"
      xlink:href="#path3889"><tspan
    id="tspan6677"
-   style="font-size:9px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Puglia</tspan></textPath></text>
+   style="font-size:9px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Apulia</tspan></textPath></text>
 
 
 
@@ -3174,7 +3174,7 @@
      id="textPath3902"
      xlink:href="#path3900"><tspan
    id="tspan6669"
-   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Roma</tspan></textPath></text>
+   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Rome</tspan></textPath></text>
 
 
 
@@ -3241,7 +3241,7 @@
      id="textPath3933"
      xlink:href="#path3922"><tspan
    id="tspan6633"
-   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Shqip\u00EBri</tspan></textPath></text>
+   style="font-size:8px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Albania</tspan></textPath></text>
 
 
 
@@ -3275,7 +3275,7 @@
      id="textPath3947"
      xlink:href="#path3942"><tspan
    id="tspan6657"
-   style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Venezia</tspan></textPath></text>
+   style="font-size:10px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Venice</tspan></textPath></text>
 
 
 
@@ -3540,7 +3540,7 @@
    xml:space="preserve"><textPath
      id="textPath4046"
      xlink:href="#path4044"
-     style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Danmark</textPath></text>
+     style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:100%;writing-mode:lr-tb;text-anchor:start;font-family:Droid Serif;-inkscape-font-specification:Droid Serif">Denmark</textPath></text>
 
 
 


### PR DESCRIPTION
Diplomacy was originally published in the United States in 1959. As such any features of the original map, including the unique combination of city and region names for game spaces and the exaggerated importance of Turkish provinces for the sake of game balance, that might have had enforceable copyright are no longer afforded copyright protection.
